### PR TITLE
Reinstate mdbook-linkcheck.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,10 @@ jobs:
           mdbook-version: '0.4.10'
           # mdbook-version: 'latest'
 
-      #- name: Install mdbook-linkcheck
-        #run: |
-          #curl -LSfs https://japaric.github.io/trust/install.sh | \
-            #sh -s -- --git Michael-F-Bryan/mdbook-linkcheck
+      - name: Install mdbook-linkcheck
+        run: |
+          curl -LSfs https://japaric.github.io/trust/install.sh | \
+            sh -s -- --git Michael-F-Bryan/mdbook-linkcheck
     
       - name: Install mdbook-mermaid
         run: cargo install mdbook-mermaid

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,7 @@ jobs:
           # mdbook-version: 'latest'
 
       - name: Install mdbook-linkcheck
-        run: |
-          curl -LSfs https://japaric.github.io/trust/install.sh | \
-            sh -s -- --git Michael-F-Bryan/mdbook-linkcheck
+        run: cargo install mdbook-linkcheck
     
       - name: Install mdbook-mermaid
         run: cargo install mdbook-mermaid

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,5 +35,5 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book
+          publish_dir: ./book/html
           cname: cppfaq.rs

--- a/book.toml
+++ b/book.toml
@@ -13,11 +13,6 @@ additional-js = ["third_party/mermaid/mermaid.min.js", "third_party/mermaid/merm
 cname = "cppfaq.rs"
 git-repository-url = "https://github.com/google/rust-design-faq"
 
-# We'd like to enable linkcheck, but at present it causes
-# trouble because mdbook disambiguates the output into different
-# subdirectories 'html' and 'linkcheck'. It's not yet clear how
-# to direct github pages to pay attention to the 'html' directory.
-# TODO - work on
-#[output.linkcheck]
-#follow-web-links = true
-#optional = true
+[output.linkcheck]
+follow-web-links = true
+optional = true

--- a/src/codebase.md
+++ b/src/codebase.md
@@ -162,7 +162,7 @@ There can be a third option if you're using async Rust. If the data isn't availa
 
 ## How do I do a singleton?
 
-Use [OnceCell](https://docs.rs/once_cell/1.7.2/once_cell/) for now. [This should arrive in the standard library](https://doc.rust-lang.org/std/lazy/struct.Lazy.html) in future.
+Use [OnceCell](https://doc.rust-lang.org/std/cell/struct.OnceCell.html).
 
 ## What's the best way to retrofit Rust's parallelism benefits to an existing codebase?
 


### PR DESCRIPTION
It was failing under github actions. We'll re-enable it in this
pull request.