### PR TITLE
Update constructor guidance

### DIFF
--- a/src/signatures.md
+++ b/src/signatures.md
@@ -101,10 +101,10 @@ fn main() {
 You can't do this:
 
 ```rust
-struct BirthdayCard {}
+# struct BirthdayCard {}
 impl BirthdayCard {
     fn new(name: &str) -> BirthdayCard {
-      Self{}
+#       Self{}
       // ...
     }
 
@@ -119,14 +119,14 @@ impl BirthdayCard {
 If you have a default constructor, and a few variants for other cases, you can simply write them as different static methods. An idiomatic way to do this is to write a `new()` constructor and then `with_foo()` constructors that apply the given "foo" when constructing.
 
 ```rust
-struct Racoon {}
+# struct Racoon {}
 impl Racoon {
   fn new() -> Racoon {
-      Self{}
+#       Self{}
       // ...
   }
   fn with_age(age: usize) -> Racoon {
-      Self{}
+#       Self{}
       // ...
   }
 }
@@ -135,14 +135,14 @@ impl Racoon {
 If you have have a bunch of constructors and no default, it may make sense to instead provide a set of `new_foo()` constructors.
 
 ```rust
-struct Animal {}
+# struct Animal {}
 impl Animal {
   fn new_squirrel() -> Animal {
-      Self{}
+#       Self{}
       // ...
   }
   fn new_badger() -> Animal {
-      Self{}
+#       Self{}
       // ...
   }
 }
@@ -158,12 +158,12 @@ impl BirthdayCardBuilder {
     fn new(name: &str) -> BirthdayCardBuilder { ... }
 
     fn age(&mut self, age: i32) -> &mut BirthdayCardBuilder {
-        self
+#         self
         // ...
      }
 
     fn text(&mut self, text: &str) -> &mut BirthdayCardBuilder {
-        self
+#         self
         // ...
      }
 
@@ -174,25 +174,25 @@ impl BirthdayCardBuilder {
 You can then [chain these](https://rust-lang.github.io/api-guidelines/type-safety.html#non-consuming-builders-preferred) into short or long constructions, passing parameters as necessary:
 
 ```rust
-struct BirthdayCard {}
-
-struct BirthdayCardBuilder {}
-impl BirthdayCardBuilder {
-    fn new(name: &str) -> BirthdayCardBuilder { ... }
-
-    fn age(&mut self, age: i32) -> &mut BirthdayCardBuilder {
-        self
-        // ...
-     }
-
-    fn text(&mut self, text: &str) -> &mut BirthdayCardBuilder {
-        self
-        // ...
-     }
-
-    fn build(self) -> BirthdayCard { BirthdayCard { /* ... */ } }
-}
-
+# struct BirthdayCard {}
+#
+# struct BirthdayCardBuilder {}
+# impl BirthdayCardBuilder {
+#     fn new(name: &str) -> BirthdayCardBuilder { ... }
+#
+#     fn age(&mut self, age: i32) -> &mut BirthdayCardBuilder {
+#         self
+#         // ...
+#      }
+#
+#     fn text(&mut self, text: &str) -> &mut BirthdayCardBuilder {
+#         self
+#         // ...
+#      }
+#
+#     fn build(self) -> BirthdayCard { BirthdayCard { /* ... */ } }
+# }
+#
  fn main() {
     let card = BirthdayCardBuilder::new("Paul")
         .age(64)

--- a/src/signatures.md
+++ b/src/signatures.md
@@ -103,7 +103,10 @@ You can't do this:
 ```rust
 struct BirthdayCard {}
 impl BirthdayCard {
-    fn new(name: &str) -> BirthdayCard { ... }
+    fn new(name: &str) -> BirthdayCard {
+      Self{}
+      // ...
+    }
 
     // Can't add more overloads:
     //
@@ -116,18 +119,32 @@ impl BirthdayCard {
 If you have a default constructor, and a few variants for other cases, you can simply write them as different static methods. An idiomatic way to do this is to write a `new()` constructor and then `with_foo()` constructors that apply the given "foo" when constructing.
 
 ```rust
+struct Racoon {}
 impl Racoon {
-  fn new() -> Racoon { ... }
-  fn with_age(age: usize) -> Racoon { ... }
+  fn new() -> Racoon {
+      Self{}
+      // ...
+  }
+  fn with_age(age: usize) -> Racoon {
+      Self{}
+      // ...
+  }
 }
 ```
 
 If you have have a bunch of constructors and no default, it may make sense to instead provide a set of `new_foo()` constructors.
 
 ```rust
+struct Animal {}
 impl Animal {
-  fn new_squirrel() -> Animal { ... }
-  fn new_badger() -> Animal { ... }
+  fn new_squirrel() -> Animal {
+      Self{}
+      // ...
+  }
+  fn new_badger() -> Animal {
+      Self{}
+      // ...
+  }
 }
 ```
 
@@ -140,37 +157,48 @@ struct BirthdayCardBuilder {}
 impl BirthdayCardBuilder {
     fn new(name: &str) -> BirthdayCardBuilder { ... }
 
-    fn age(&mut self, age: i32) -> &mut BirthdayCardBuilder { ... }
+    fn age(&mut self, age: i32) -> &mut BirthdayCardBuilder {
+        self
+        // ...
+     }
 
-    fn text(&mut self, text: &str) -> &mut BirthdayCardBuilder { ... }
+    fn text(&mut self, text: &str) -> &mut BirthdayCardBuilder {
+        self
+        // ...
+     }
 
-    fn build(self) -> BirthdayCard { ... }
+    fn build(self) -> BirthdayCard { BirthdayCard { /* ... */ } }
 }
 ```
 
 You can then [chain these](https://rust-lang.github.io/api-guidelines/type-safety.html#non-consuming-builders-preferred) into short or long constructions, passing parameters as necessary:
 
 ```rust
-# struct BirthdayCard;
-# impl BirthdayCard {
-#     fn new(name: &str) -> BirthdayCard {
-#         Self
-#         // ...
-#     }
-#
-#     fn age(&mut self, age: i32) -> &mut BirthdayCard {
-#         self
-#         // ...
-#     }
-#
-#     fn text(&mut self, text: &str) -> &mut BirthdayCard {
-#         self
-#       // ...
-#     }
-# }
-# fn main() {
-let card = BirthdayCard::new("Paul").age(64).text("Happy Valentine's Day!");
-# }
+struct BirthdayCard {}
+
+struct BirthdayCardBuilder {}
+impl BirthdayCardBuilder {
+    fn new(name: &str) -> BirthdayCardBuilder { ... }
+
+    fn age(&mut self, age: i32) -> &mut BirthdayCardBuilder {
+        self
+        // ...
+     }
+
+    fn text(&mut self, text: &str) -> &mut BirthdayCardBuilder {
+        self
+        // ...
+     }
+
+    fn build(self) -> BirthdayCard { BirthdayCard { /* ... */ } }
+}
+
+ fn main() {
+    let card = BirthdayCardBuilder::new("Paul")
+        .age(64)
+        .text("Happy Valentine's Day!")
+        .build();
+}
 ```
 
 Note another advantage of builders: Overloaded constructors often don't provide all possible combinations of parameters, whereas with the builder pattern, you can combine exactly the parameters you want.

--- a/src/signatures.md
+++ b/src/signatures.md
@@ -148,14 +148,17 @@ impl Animal {
 }
 ```
 
-For a more complex situation, you may use [the builder pattern](https://rust-lang.github.io/api-guidelines/type-safety.html#builders-enable-construction-of-complex-values-c-builder). The builder has a set of methods which take `&mut self` and return `&mut Self`. Then a `build()` method consumes the builder as `self` and returns the final constructed object.
+For a more complex situation, you may use [the builder pattern](https://rust-lang.github.io/api-guidelines/type-safety.html#builders-enable-construction-of-complex-values-c-builder). The builder has a set of methods which take `&mut self` and return `&mut Self`. Then add a `build()` that returns the final constructed object.
 
 ```rust
 struct BirthdayCard {}
 
 struct BirthdayCardBuilder {}
 impl BirthdayCardBuilder {
-    fn new(name: &str) -> BirthdayCardBuilder { ... }
+    fn new(name: &str) -> BirthdayCardBuilder {
+#       Self{}
+      // ...
+    }
 
     fn age(&mut self, age: i32) -> &mut BirthdayCardBuilder {
 #         self
@@ -167,7 +170,7 @@ impl BirthdayCardBuilder {
         // ...
      }
 
-    fn build(self) -> BirthdayCard { BirthdayCard { /* ... */ } }
+    fn build(&mut self) -> BirthdayCard { BirthdayCard { /* ... */ } }
 }
 ```
 
@@ -178,7 +181,10 @@ You can then [chain these](https://rust-lang.github.io/api-guidelines/type-safet
 #
 # struct BirthdayCardBuilder {}
 # impl BirthdayCardBuilder {
-#     fn new(name: &str) -> BirthdayCardBuilder { ... }
+#     fn new(name: &str) -> BirthdayCardBuilder {
+#       Self{}
+#       // ...
+#     }
 #
 #     fn age(&mut self, age: i32) -> &mut BirthdayCardBuilder {
 #         self
@@ -190,7 +196,7 @@ You can then [chain these](https://rust-lang.github.io/api-guidelines/type-safet
 #         // ...
 #      }
 #
-#     fn build(self) -> BirthdayCard { BirthdayCard { /* ... */ } }
+#     fn build(&mut self) -> BirthdayCard { BirthdayCard { /* ... */ } }
 # }
 #
  fn main() {

--- a/src/signatures.md
+++ b/src/signatures.md
@@ -101,44 +101,50 @@ fn main() {
 You can't do this:
 
 ```rust
-# struct BirthdayCard;
+struct BirthdayCard {}
 impl BirthdayCard {
-    fn new(name: &str) -> BirthdayCard {
-#       Self
-        // ...
-    }
+    fn new(name: &str) -> BirthdayCard { ... }
 
     // Can't add more overloads:
     //
-    // fn new(name: &str, age: i32) -> BirthdayCard {
-    //   ...
-    // }
+    // fn new(name: &str, age: i32) -> BirthdayCard { ... }
     //
-    // fn new(name: &str, text: &str) -> BirthdayCard {
-    //   ...
-    // }
+    // fn new(name: &str, text: &str) -> BirthdayCard { ... }
 }
 ```
 
-Instead, use [the builder pattern](https://rust-lang.github.io/api-guidelines/type-safety.html#builders-enable-construction-of-complex-values-c-builder). In place of overloaded constructors, add methods which take `&mut self` and return `&mut Self`:
+If you have a default constructor, and a few variants for other cases, you can simply write them as different static methods. An idiomatic way to do this is to write a `new()` constructor and then `with_foo()` constructors that apply the given "foo" when constructing.
 
 ```rust
-# struct BirthdayCard;
-impl BirthdayCard {
-    fn new(name: &str) -> BirthdayCard {
-#       Self
-        // ...
-    }
+impl Racoon {
+  fn new() -> Racoon { ... }
+  fn with_age(age: usize) -> Racoon { ... }
+}
+```
 
-    fn age(&mut self, age: i32) -> &mut BirthdayCard {
-#       self
-        // ...
-    }
+If you have have a bunch of constructors and no default, it may make sense to instead provide a set of `new_foo()` constructors.
 
-    fn text(&mut self, text: &str) -> &mut BirthdayCard {
-#       self
-      // ...
-    }
+```rust
+impl Animal {
+  fn new_squirrel() -> Animal { ... }
+  fn new_badger() -> Animal { ... }
+}
+```
+
+For a more complex situation, you may use [the builder pattern](https://rust-lang.github.io/api-guidelines/type-safety.html#builders-enable-construction-of-complex-values-c-builder). The builder has a set of methods which take `&mut self` and return `&mut Self`. Then a `build()` method consumes the builder as `self` and returns the final constructed object.
+
+```rust
+struct BirthdayCard {}
+
+struct BirthdayCardBuilder {}
+impl BirthdayCardBuilder {
+    fn new(name: &str) -> BirthdayCardBuilder { ... }
+
+    fn age(&mut self, age: i32) -> &mut BirthdayCardBuilder { ... }
+
+    fn text(&mut self, text: &str) -> &mut BirthdayCardBuilder { ... }
+
+    fn build(self) -> BirthdayCard { ... }
 }
 ```
 


### PR DESCRIPTION
Suggest new() and with_foo(), or new_a(), new_b().

And update the builder pattern to have a separate builder
type that produces the constructed thing from it.